### PR TITLE
Refactor dummy test controllers only used for annotation-crawling

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -17,3 +17,4 @@ disabled:
   - phpdoc_separation
   - no_blank_lines_after_class_opening
   - multiline_array_trailing_comma
+  - phpdoc_trim

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -17,5 +17,7 @@ disabled:
   - phpdoc_separation
   - no_blank_lines_after_class_opening
   - multiline_array_trailing_comma
-  - phpdoc_trim
-  - phpdoc_indent
+
+finder:
+  not-path:
+    - "tests/test_app/src/Controller"

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -18,3 +18,4 @@ disabled:
   - no_blank_lines_after_class_opening
   - multiline_array_trailing_comma
   - phpdoc_trim
+  - phpdoc_indent

--- a/tests/TestCase/Controller/DocsControllerTest.php
+++ b/tests/TestCase/Controller/DocsControllerTest.php
@@ -109,7 +109,7 @@ class DocsControllerTest extends TestCase
             'library' => [
                 'testdoc' => [
                     'include' => APP . 'src',
-                    'exclude' => APP . 'src' . DS . 'Controller' . DS . 'ExcludeController'
+                    'exclude' => APP . 'src' . DS . 'Controller' . DS . 'DummyExcludeController'
                 ]
             ]
         ]));

--- a/tests/test_app/src/Controller/DummyExcludeController.php
+++ b/tests/test_app/src/Controller/DummyExcludeController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Dummy test_app controller required for crawl-generated swagger document.
+ * Dummy test_app controller only used for crawl-generating a swagger document.
  *
  *
     @SWG\Get(
@@ -15,3 +15,7 @@
         )
     )
  */
+class DummyExcludeController
+{
+
+}

--- a/tests/test_app/src/Controller/DummyInlcudeController.php
+++ b/tests/test_app/src/Controller/DummyInlcudeController.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Dummy test_app controller required for crawl-generated swagger document.
+ * Dummy test_app controller only used for crawl-generating a swagger document.
  *
  *
     @SWG\Swagger(
@@ -60,3 +61,7 @@
         )
     )
  */
+class DummyIncludeController
+{
+
+}


### PR DESCRIPTION
Styleci defaults will f**k up the docblock annotations in the dummy controllers used for crawl-generating the swagger test json documents. This PR prevents this by completely ignoring the dummy test controller directory.

Could also have been done by the following but not without impacting the overall source-tree:
- making the dummy controllers look like actual PHP classes
- disabling `styleci` phpdoc_trim fixer (to prevent removing the annotations)
- disabling styleci `phpdoc_indent` (to prevent unreadable vertical alignment)
