### PR TITLE
Adds json document index

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -17,6 +17,7 @@ disabled:
   - phpdoc_separation
   - no_blank_lines_after_class_opening
   - multiline_array_trailing_comma
+  - return
 
 finder:
   not-path:

--- a/README.md
+++ b/README.md
@@ -84,14 +84,16 @@ return [
 
 ### UI section
 
-Use the `ui` section to customize the following options:
+Use the `ui` section to customize the following Swagger-UI options:
 
 - `title`: sets the Swagger-UI page title, defaults to `cakephp-swagger`
 - `validator`: show/hide the validator image, defaults to `true`
 - `route`: expose the UI using a custom route, defaults to `/alt3/swagger/`
 - `schemes`: array used to specify third field
-[used by the UI to generate the BASE URL](https://github.com/alt3/cakephp-swagger/issues/6)
+[used to generate the BASE URL](https://github.com/alt3/cakephp-swagger/issues/6)
 (`host` and `basePath` are fetched realtime), defaults to `null`
+
+> Please note that the UI will auto-load the first document found in the library.
 
 ### Docs section
 
@@ -111,6 +113,13 @@ Use the `library` section to specify one or multiple swagger documents so:
 - this plugin can expose the json at `http://your.app/alt3/swagger/docs/:id`
 (so it can be used by the UI)
 
+The following library example would result in:
+
+- swagger-php scanning all files and folders defined in `include`
+- swagger-php ignoring all files and folders defined in `exclude`
+- two endpoints serving json swagger documents:
+    - `http://your.app/alt3/swagger/docs/api`
+    - `http://your.app/alt3/swagger/docs/editor`
 
 ```php
 'library' => [
@@ -130,16 +139,25 @@ Use the `library` section to specify one or multiple swagger documents so:
 ]
 ```
 
-The above library will result in:
+It would also make `http://your.app/alt3/swagger/docs` produce a json list
+with links to all available documents similar to the example below.
 
-- swagger-php scanning all files and folders defined in `include`
-- swagger-php ignoring all files and folders defined in `exclude`
-- two document endpoints serving json at:
-    - `http://your.app/alt3/swagger/docs/api`
-    - `http://your.app/alt3/swagger/docs/editor`
+```json
+{
+    "success": true,
+    "data": [
+        {
+            "document": "api",
+            "link": "http://your.app/alt3/swagger/docs/api"
+        },
+        {
+            "document": "editor",
+            "link": "http://your.app/alt3/swagger/docs/editor"
+        }
+    ]
+}
+```
 
-> **Note**: the UI will auto-load the first document found in the library
-> section.
 
 ## Quickstart Annotation Example
 
@@ -221,7 +239,7 @@ Which should result in:
 
 - [The Swagger Specification](https://github.com/swagger-api/swagger-spec)
 - [PHP Annotation Examples](https://github.com/zircote/swagger-php/tree/master/Examples)
-
+- [Swagger Document Checklist](http://apievangelist.com/2015/06/15/my-minimum-viable-definition-for-a-complete-swagger-api-definition/)
 
 ## Contribute
 

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -11,7 +11,8 @@ class AppController extends BaseController
     /**
      * @var array that will hold merged configuration settings.
      */
-    public static $config;
+    public $config;
+
     /**
      * @var array holding required default configuration settings.
      */
@@ -34,7 +35,7 @@ class AppController extends BaseController
         parent::initialize();
 
         if (Configure::read('Swagger')) {
-            static::$config = Hash::merge(static::$defaultConfig, Configure::read('Swagger'));
+            $this->config = Hash::merge(static::$defaultConfig, Configure::read('Swagger'));
         }
     }
 }

--- a/src/Controller/UiController.php
+++ b/src/Controller/UiController.php
@@ -16,7 +16,7 @@ class UiController extends AppController
     public function index()
     {
         $this->viewBuilder()->layout(false);
-        $this->set('uiConfig', static::$config['ui']);
+        $this->set('uiConfig', $this->config['ui']);
         $this->set('url', $this->getDefaultDocumentUrl());
     }
 
@@ -26,12 +26,12 @@ class UiController extends AppController
     public function getDefaultDocumentUrl()
     {
         // Use Swagger petstore if library contains no entries
-        if (empty(static::$config['library'])) {
+        if (empty($this->config['library'])) {
             return 'http://petstore.swagger.io/v2/swagger.json';
         }
 
         // Otherwise generate URL using first document in the library
-        $defaultDocument = key(static::$config['library']);
+        $defaultDocument = key($this->config['library']);
 
         return Router::url([
             'plugin' => 'Alt3/Swagger',

--- a/src/Template/Docs/index.ctp
+++ b/src/Template/Docs/index.ctp
@@ -1,3 +1,3 @@
 <?php
 
-echo $swaggerString;
+echo $json;

--- a/tests/TestCase/Controller/DocsControllerTest.php
+++ b/tests/TestCase/Controller/DocsControllerTest.php
@@ -183,7 +183,6 @@ EOF;
         $this->assertNotSame($result->paths[0]->path, '/taxis'); // In ExcludeController so should not be present
     }
 
-
     /**
      * Make sure an exception is thrown when swagger document cannot be
      * written to the filesystem.
@@ -296,7 +295,6 @@ EOF;
     {
         $obj = new stdClass();
         $obj->class = new \ReflectionClass(get_class($object));
-
 
         // make all methods accessible
         $obj->methods = new stdClass();

--- a/tests/TestCase/Controller/DocsCustomRouteIntegrationTest.php
+++ b/tests/TestCase/Controller/DocsCustomRouteIntegrationTest.php
@@ -3,7 +3,7 @@ namespace Alt3\Swagger\Test\TestCase\Controller;
 
 use Cake\TestSuite\IntegrationTestCase;
 
-class UiControllerCustomDocsRouteTest extends IntegrationTestCase
+class DocsCustomRouteIntegrationTest extends IntegrationTestCase
 {
 
     /**

--- a/tests/TestCase/Controller/UiControllerTest.php
+++ b/tests/TestCase/Controller/UiControllerTest.php
@@ -77,7 +77,6 @@ class UiControllerTest extends TestCase
         $obj = new stdClass();
         $obj->class = new \ReflectionClass(get_class($object));
 
-
         // make all methods accessible
         $obj->methods = new stdClass();
         $classMethods = $obj->class->getMethods();

--- a/tests/TestCase/Controller/UiControllerTest.php
+++ b/tests/TestCase/Controller/UiControllerTest.php
@@ -7,6 +7,41 @@ use StdClass;
 
 class UiControllerTest extends TestCase
 {
+
+    /**
+     * @var \Alt3\Swagger\Controller\UiController
+     */
+    protected $controller;
+
+    /**
+     * @var array Default AppController settings every test will start with.
+     */
+    protected static $defaultConfig = [
+        'docs' => [
+            'crawl' => true
+        ],
+        'ui' => [
+            'title' => 'cakephp-swagger'
+        ]
+    ];
+
+    /**
+     * setUp method executed before every testMethod.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->controller = new UiController();
+    }
+
+    /**
+     * Make sure our tests are using the expected configuration settings.
+     */
+    public function testDefaultSettings()
+    {
+        $this->assertSame(self::$defaultConfig, UiController::$defaultConfig);
+    }
+
     /**
      * Make sure the UI will auto-load the correct default document URL.
      *
@@ -14,43 +49,52 @@ class UiControllerTest extends TestCase
      **/
     public function testMethodGetDefaultDocumentUrl()
     {
-        // test without library document
-        $controller = new UiController();
-        $reflection = $reflection = $this->getReflection($controller, 'getDefaultDocumentUrl', 'config');
-        $reflection->property->setValue([
-            'docs' => []
-        ]);
-        $result = $reflection->method->invokeArgs($controller, []);
-        $this->assertTextEquals($result, 'http://petstore.swagger.io/v2/swagger.json');
+        $reflection = self::getReflection($this->controller);
+
+        // test without library documents
+        $reflection->properties->config->setValue($this->controller, array_merge(self::$defaultConfig, [
+            'library' => []
+        ]));
+        $result = $reflection->methods->getDefaultDocumentUrl->invokeArgs($this->controller, []);
+        $this->assertSame($result, 'http://petstore.swagger.io/v2/swagger.json');
 
         // test with library document
-        $reflection->property->setValue([
+        $reflection->properties->config->setValue($this->controller, [
             'library' => [
                 'testdoc' => []
             ]
         ]);
-        $result = $reflection->method->invokeArgs($controller, []);
-        $this->assertTextEquals($result, 'http://localhost/alt3/swagger/docs/testdoc');
+        $result = $reflection->methods->getDefaultDocumentUrl->invokeArgs($this->controller, []);
+        $this->assertSame($result, 'http://localhost/alt3/swagger/docs/testdoc');
     }
 
     /**
-     * Convenience function to return an object with reflection class, accessible
-     * protected method and optional accessible protected property.
+     * Convenience function to return an object with reflection class,
+     * accessible protected methods and accessible protected properties.
      */
-    public function getReflection($object, $method = false, $property = false)
+    protected static function getReflection($object)
     {
         $obj = new stdClass();
         $obj->class = new \ReflectionClass(get_class($object));
-        $obj->method = null;
-        if ($method) {
-            $obj->method = $obj->class->getMethod($method);
-            $obj->method->setAccessible(true);
-        }
-        if ($property) {
-            $obj->property = $obj->class->getProperty($property);
-            $obj->property->setAccessible(true);
+
+
+        // make all methods accessible
+        $obj->methods = new stdClass();
+        $classMethods = $obj->class->getMethods();
+        foreach ($classMethods as $method) {
+            $methodName = $method->name;
+            $obj->methods->{$methodName} = $obj->class->getMethod($methodName);
+            $obj->methods->{$methodName}->setAccessible(true);
         }
 
+        // make all properties accessible
+        $obj->properties = new stdClass();
+        $classProperties = $obj->class->getProperties();
+        foreach ($classProperties as $property) {
+            $propertyName = $property->name;
+            $obj->properties->{$propertyName} = $obj->class->getProperty($propertyName);
+            $obj->properties->{$propertyName}->setAccessible(true);
+        }
         return $obj;
     }
 }


### PR DESCRIPTION
The `docs` index action now produces a json response with `data` element:
- containing links to all available documents found in the library
- empty if the library contains no docs
