### PR TITLE
$swaggerOptions should be an empty array, not null

### DIFF
--- a/src/Lib/SwaggerTools.php
+++ b/src/Lib/SwaggerTools.php
@@ -37,7 +37,7 @@ class SwaggerTools
         }
 
         // otherwise crawl-generate a fresh document
-        $swaggerOptions = null;
+        $swaggerOptions = [];
         if (Configure::read("Swagger.library.$id.exclude")) {
             $swaggerOptions = [
                 'exclude' => Configure::read("Swagger.library.$id.exclude")


### PR DESCRIPTION
With version 2.0.8 of `zircote/swagger-php`, the following warnings are being generated:

```
Warning (2): array_key_exists() expects parameter 2 to be array, null given [ROOT/vendor/zircote/swagger-php/src/functions.php, line 33]
Warning (2): array_key_exists() expects parameter 2 to be array, null given [ROOT/vendor/zircote/swagger-php/src/functions.php, line 34]
Warning (2): array_key_exists() expects parameter 2 to be array, null given [ROOT/vendor/zircote/swagger-php/src/functions.php, line 35]
Warning (2): array_key_exists() expects parameter 2 to be array, null given [ROOT/vendor/zircote/swagger-php/src/functions.php, line 36]
```

This is because `swagger-php` is no longer supressing warnings when settings `$options` for `Swagger\scan()`.

The fix is really simple, we just need to set `$swaggerOptions` to an empty array instead of `null`. I have tested this against 2.0.7 and 2.0.8 of `swagger-php`.