### PR TITLE
Add support for providing custom Analyser object

### DIFF
--- a/src/Lib/SwaggerTools.php
+++ b/src/Lib/SwaggerTools.php
@@ -43,6 +43,9 @@ class SwaggerTools
                 'exclude' => Configure::read("Swagger.library.$id.exclude")
             ];
         }
+        if (Configure::read('Swagger.analyser')) {
+            $swaggerOptions['analyser'] = Configure::read('Swagger.analyser');
+        }
         $swagger = \Swagger\scan(Configure::read("Swagger.library.$id.include"), $swaggerOptions);
 
         // set object properties required by UI to generate the BASE URL

--- a/tests/TestCase/Lib/SwaggerToolsTest.php
+++ b/tests/TestCase/Lib/SwaggerToolsTest.php
@@ -91,7 +91,8 @@ class SwaggerToolsTest extends TestCase
                     'include' => APP . 'src',
                     'exclude' => APP . 'src' . DS . 'Controller' . DS . 'DummyExcludeController'
                 ]
-            ]
+            ],
+            'analyser' => new \Swagger\StaticAnalyser()
         ]));
 
         $result = $reflection->methods->getSwaggerDocument->invokeArgs($this->lib, ['testdoc', 'www.test.app']);


### PR DESCRIPTION
You can provide a custom swagger Analyser class using Swagger configuration as follows:

```php
<?php
use App\Swagger\MyCustomAnalyser;

return [
    'Swagger' => [
        'analyser' => new MyCustomAnalyser()
    ]
];

```