### PR TITLE
Bump php-minversion to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
 
 sudo: false
 
@@ -16,10 +15,10 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 5.4
+    - php: 7.1
       env: PHPCS=1 PHPUNIT=0
 
-    - php: 7.0
+    - php: 7.1
       env: CODECOVERAGE=1 PHPUNIT=0
 
     - php: hhvm
@@ -42,11 +41,11 @@ before_script:
   - cp phpunit.xml.dist phpunit.xml
 
 script:
-  - sh -c "if [ '$PHPUNIT' = '1' ]; then phpunit; fi"
+  - sh -c "if [ '$PHPUNIT' = '1' ]; then vendor/bin/phpunit; fi"
 
   - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests ./config --ignore=.webroot; fi"
 
-  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then phpunit --coverage-clover=clover.xml || true; fi"
+  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then vendor/bin/phpunit --coverage-clover=clover.xml || true; fi"
   - sh -c "if [ '$CODECOVERAGE' = '1' ]; then wget -O codecov.sh https://codecov.io/bash; fi"
   - sh -c "if [ '$CODECOVERAGE' = '1' ]; then bash codecov.sh; fi"
 

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,12 @@
     "type": "cakephp-plugin",
     "license": "MIT",
     "require": {
-        "php": ">=5.4.16",
+        "php": ">=5.6",
         "cakephp/cakephp": "~3.1",
         "zircote/swagger-php": "^2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "5.*"
     },
     "support": {
         "issues": "https://github.com/alt3/cakephp-swagger/issues",

--- a/tests/TestCase/Shell/SwaggerShellTest.php
+++ b/tests/TestCase/Shell/SwaggerShellTest.php
@@ -21,7 +21,7 @@ class SwaggerShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo');
+        $this->io = $this->createMock('Cake\Console\ConsoleIo');
         $this->shell = new SwaggerShell($this->io);
     }
 


### PR DESCRIPTION
This PR changes the required PHP version to at least (supported) 5.6 to keep in sync with the swagger-php repo (see https://github.com/zircote/swagger-php/issues/367).